### PR TITLE
fix(statusline): close transcript fd if read fails

### DIFF
--- a/statusline.js
+++ b/statusline.js
@@ -201,8 +201,11 @@ process.stdin.on('end', () => {
             const readBytes = stat.size - startOffset;
             const buf = Buffer.alloc(readBytes);
             const fd = fs.openSync(transcriptPath, 'r');
-            fs.readSync(fd, buf, 0, readBytes, startOffset);
-            fs.closeSync(fd);
+            try {
+              fs.readSync(fd, buf, 0, readBytes, startOffset);
+            } finally {
+              fs.closeSync(fd);
+            }
             let content = buf.toString('utf8');
             if (startOffset > 0) {
               const nl = content.indexOf('\n');


### PR DESCRIPTION
## Summary

`fs.readSync` between `openSync` and `closeSync` (statusline.js:202-204) is unguarded — if it throws (e.g. `ENOMEM` allocating the read `Buffer`, `EIO` on a flaky disk), the file descriptor leaks until the process exits. Wrapped in `try/finally` so the fd is always released on the error path.

The process is short-lived so the practical impact is small; this is correctness hygiene rather than a fix for an observed bug.

## Diff

```js
const fd = fs.openSync(transcriptPath, 'r');
-fs.readSync(fd, buf, 0, readBytes, startOffset);
-fs.closeSync(fd);
+try {
+  fs.readSync(fd, buf, 0, readBytes, startOffset);
+} finally {
+  fs.closeSync(fd);
+}
```

## Test plan

- [x] `node tests/statusline-smoke.test.js` — existing suite passes
- No new test: the leak is unobservable from output, and the change is the canonical try/finally resource pattern. Happy to add a fs-stubbed test if you want one.