### PR TITLE
fix(statusline): validate session_id before using in paths

### DIFF
--- a/statusline.js
+++ b/statusline.js
@@ -30,7 +30,11 @@ process.stdin.on('end', () => {
     };
     const model = shortModel(data.model?.display_name || 'Claude');
     const dir = data.workspace?.current_dir || process.cwd();
-    const session = data.session_id || '';
+    // session_id is used to build paths under os.tmpdir() and ~/.claude/projects.
+    // Claude Code emits a UUID, but treat any unexpected shape as absent so a
+    // malformed value can't traverse out of those locations (e.g. "../foo").
+    const rawSession = data.session_id || '';
+    const session = /^[A-Za-z0-9_-]{1,128}$/.test(rawSession) ? rawSession : '';
     const rawRemaining = data.context_window?.remaining_percentage;
     const remaining = (rawRemaining == null || rawRemaining === '') ? NaN : Number(rawRemaining);
     const homeDir = os.homedir();

--- a/tests/statusline-smoke.test.js
+++ b/tests/statusline-smoke.test.js
@@ -421,6 +421,39 @@ check('cache reset renders after compact when current_usage is null', () => {
   assert(text.includes('cache:reset'), text);
 });
 
+check('malformed session_id is rejected before being used in paths', () => {
+  const dir = makeTempDir();
+  const claude = makeTempDir();
+  const slugDir = path.join(claude, 'projects', slugFor(dir));
+  fs.mkdirSync(slugDir, { recursive: true });
+
+  // Plant a transcript at the path that '../valid' would resolve to when
+  // joined under the project slug dir. Unguarded code would read this file
+  // and render the TTL countdown; the validation should keep it untouched.
+  const traversedPath = path.join(claude, 'projects', 'valid.jsonl');
+  fs.writeFileSync(traversedPath, JSON.stringify({
+    type: 'assistant',
+    timestamp: new Date(Date.now() - 60 * 1000).toISOString(),
+    message: { usage: { cache_read_input_tokens: 1000, cache_creation_input_tokens: 10, cache_creation: { ephemeral_1h_input_tokens: 10 } } }
+  }) + '\n');
+
+  const { text } = runStatusline(inputFor(dir, {
+    session_id: '../valid',
+    context_window: {
+      current_usage: {
+        cache_read_input_tokens: 1000,
+        cache_creation_input_tokens: 10,
+        input_tokens: 0
+      }
+    }
+  }), { CLAUDE_CONFIG_DIR: claude });
+
+  // Cache counters from stdin still render (they don't need a session_id),
+  // but the TTL bucket/countdown — which comes from the transcript — must not.
+  assert(text.includes('cache 99% ↓1k +10'), text);
+  assert(!/\b(?:1h|5m):/.test(text), 'transcript at traversed path must not be read: ' + text);
+});
+
 check('transcript slug encoding replaces dots in directory paths', () => {
   const parent = makeTempDir();
   const dir = path.join(parent, 'dotted.proj');


### PR DESCRIPTION
## Summary

`session_id` from stdin is concatenated into two filesystem paths:
- `<os.tmpdir()>/claude-ctx-${session}.json` — bridge file for the context-monitor hook
- `<claudeDir>/projects/<slug>/${session}.jsonl` — transcript lookup for cache TTL

Claude Code emits a UUID, so the value is safe in practice — but the script trusts stdin shape without checking. A malformed value like `"../foo"` would traverse out of those directories. Under `~/.claude/projects` this means an arbitrary `.jsonl` could be read as a transcript and feed the cache TTL segment.

Treat any `session_id` that does not match `[A-Za-z0-9_-]{1,128}` as absent. All existing usages are already guarded by `if (session)` and degrade silently when empty, matching the "exit 0 on any error" rule from `CLAUDE.md`.

## Diff

```js
-const session = data.session_id || '';
+const rawSession = data.session_id || '';
+const session = /^[A-Za-z0-9_-]{1,128}$/.test(rawSession) ? rawSession : '';
```

## Test plan

- [x] `node tests/statusline-smoke.test.js` — full suite passes
- [x] New smoke test (`malformed session_id is rejected before being used in paths`) plants a transcript at the path `"../valid"` resolves to, and confirms the TTL countdown is **not** rendered. Verified it fails on `main` (renders `1h:59m` from the traversed transcript) and passes with the fix.