### PR TITLE
fix(statusline): read transcript via transcript_path, not a current_dir slug

### DIFF
--- a/statusline.js
+++ b/statusline.js
@@ -186,12 +186,22 @@ process.stdin.on('end', () => {
       // reset (current_usage is null but earlier messages had cache activity).
       if (session && (read > 0 || write > 0 || usageNull)) {
         try {
-          // Claude Code slug encoding: drive colon, separators, AND dots → '-'
-          // (e.g. C:\Users\ilyap\.openclaw → C--Users-ilyap--openclaw).
-          // Without the dot replacement, transcripts inside hidden dirs aren't
-          // found and the cache TTL/timestamp segment silently drops.
-          const slug = dir.replace(/[:\\\/.]/g, '-');
-          const transcriptPath = path.join(claudeDir, 'projects', slug, `${session}.jsonl`);
+          // Prefer the transcript path Claude Code hands us directly. Rebuilding
+          // it from a dir slug is fragile (drive letters, dots in hidden dirs)
+          // and — more importantly — wrong once current_dir diverges from the
+          // launch dir: the transcript stays anchored to project_dir's slug, so
+          // a slug built from current_dir points at a path that doesn't exist
+          // and the cache TTL/timestamp segment silently drops.
+          let transcriptPath = data.transcript_path;
+          if (!transcriptPath) {
+            // Fallback for Claude Code builds that omit transcript_path: rebuild
+            // the slug from the launch dir (project_dir), not current_dir, with
+            // the same colon/separator/dot → '-' encoding Claude Code uses
+            // (e.g. C:\Users\ilyap\.openclaw → C--Users-ilyap--openclaw).
+            const slugDir = data.workspace?.project_dir || dir;
+            const slug = slugDir.replace(/[:\\\/.]/g, '-');
+            transcriptPath = path.join(claudeDir, 'projects', slug, `${session}.jsonl`);
+          }
           if (fs.existsSync(transcriptPath)) {
             const stat = fs.statSync(transcriptPath);
             // Read 1 extra byte before the window so the first \n distinguishes

--- a/tests/statusline-smoke.test.js
+++ b/tests/statusline-smoke.test.js
@@ -444,6 +444,53 @@ check('transcript slug encoding replaces dots in directory paths', () => {
   assert(text.includes('cache 99% ↓1k +10 1h:'), text);
 });
 
+check('cache TTL reads transcript_path from stdin, ignoring the current_dir slug', () => {
+  const current = makeTempDir(); // current_dir — no transcript lives under its slug
+  const claude = makeTempDir();
+  const session = 'tp-session';
+  // Plant the transcript at an arbitrary path and hand it to the script via
+  // stdin. If the script still rebuilt a slug from current_dir it would miss it.
+  const tpath = path.join(claude, 'elsewhere', `${session}.jsonl`);
+  fs.mkdirSync(path.dirname(tpath), { recursive: true });
+  fs.writeFileSync(tpath, JSON.stringify({
+    type: 'assistant',
+    timestamp: new Date(Date.now() - 60 * 1000).toISOString(),
+    message: { usage: { cache_read_input_tokens: 1000, cache_creation_input_tokens: 10, cache_creation: { ephemeral_1h_input_tokens: 10 } } }
+  }) + '\n');
+
+  const { text } = runStatusline(inputFor(current, {
+    session_id: session,
+    transcript_path: tpath,
+    context_window: {
+      current_usage: { cache_read_input_tokens: 1000, cache_creation_input_tokens: 10, input_tokens: 0 }
+    }
+  }), { CLAUDE_CONFIG_DIR: claude });
+  assert(text.includes('cache 99% ↓1k +10 1h:'), text);
+});
+
+check('cache TTL falls back to project_dir slug (not current_dir) when transcript_path absent', () => {
+  const parent = makeTempDir();
+  const launch = path.join(parent, 'launchdir'); // project_dir — transcript anchored here
+  const current = path.join(parent, 'workdir');  // current_dir — moved here, nothing under its slug
+  fs.mkdirSync(launch);
+  fs.mkdirSync(current);
+  const claude = makeTempDir();
+  const session = 'fallback-session';
+  writeTranscript(claude, launch, session, [
+    JSON.stringify({ type: 'assistant', timestamp: new Date(Date.now() - 60 * 1000).toISOString(), message: { usage: { cache_read_input_tokens: 1000, cache_creation_input_tokens: 10, cache_creation: { ephemeral_1h_input_tokens: 10 } } } })
+  ]);
+
+  const { text } = runStatusline({
+    model: { display_name: 'Claude' },
+    session_id: session,
+    workspace: { current_dir: current, project_dir: launch },
+    context_window: {
+      current_usage: { cache_read_input_tokens: 1000, cache_creation_input_tokens: 10, input_tokens: 0 }
+    }
+  }, { CLAUDE_CONFIG_DIR: claude });
+  assert(text.includes('cache 99% ↓1k +10 1h:'), text);
+});
+
 if (failures.length > 0) {
   console.error(failures.join('\n\n'));
   process.exitCode = 1;


### PR DESCRIPTION
## Summary

The cache TTL/timestamp segment locates the session transcript by rebuilding a slug from `workspace.current_dir`:

```js
const slug = dir.replace(/[:\\\/.]/g, '-');
const transcriptPath = path.join(claudeDir, 'projects', slug, `${session}.jsonl`);
```

That breaks the moment `current_dir` diverges from the launch dir — e.g. a session started in `/repo` whose working dir later moves to `/repo/subdir`. Claude Code keeps the transcript anchored under `project_dir`'s slug, so a slug built from `current_dir` points at a directory that doesn't exist, `fs.existsSync` returns `false`, and the `1h`/`5m` TTL countdown + last-touch timestamp silently drop. (The hit-ratio counters come from stdin, so they keep rendering — which masks the gap.)

Claude Code already provides the absolute transcript path on stdin as `transcript_path` ([statusline docs](https://code.claude.com/docs/en/statusline)). Use it directly. Keep a fallback for builds that omit it, but build that slug from `project_dir` (the launch dir the transcript is anchored to) rather than `current_dir`. Using the stdin path also sidesteps the fragile drive-letter / dotted-hidden-dir slug encoding entirely.

## Diff

```js
-const slug = dir.replace(/[:\\\/.]/g, '-');
-const transcriptPath = path.join(claudeDir, 'projects', slug, `${session}.jsonl`);
+let transcriptPath = data.transcript_path;
+if (!transcriptPath) {
+  const slugDir = data.workspace?.project_dir || dir;
+  const slug = slugDir.replace(/[:\\\/.]/g, '-');
+  transcriptPath = path.join(claudeDir, 'projects', slug, `${session}.jsonl`);
+}
```

## Test plan

- [x] `node tests/statusline-smoke.test.js` — full suite passes
- [x] New test: TTL renders from a stdin `transcript_path` even when nothing exists under the `current_dir` slug
- [x] New test: with `transcript_path` absent, the fallback finds the transcript under the `project_dir` slug, not `current_dir`
- [x] Existing slug / `session_id`-traversal tests still pass — the fallback preserves the dot-encoding and the `if (session)` guard
