### PR TITLE
feat(statusline): show reasoning-effort tier as a 2-letter code after the model

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ shortened so the line fits in a 100-column terminal.
 | Segment | Meaning |
 |---------|---------|
 | `Op 4.7 (1m)` | Current model, abbreviated: family (`Op`/`So`/`Ha`/`My`) + space + version + context size (dim). `Opus 4.7 (1M context)` becomes `Op 4.7 (1m)`. Unrecognised model names are shown as-is. |
+| `Op 4.7 Hi` | Reasoning-effort tier as a dim 2-letter code (same shade as the model) glued to it: `Lo`/`Md`/`Hi`/`Xh`/`Mx` for `low`/`medium`/`high`/`xhigh`/`max`. Reflects the live value (including mid-session `/effort` changes). Shown only on models that report `effort.level`; absent on models that don't support reasoning effort |
 | `claude-…tusline (main)` | Working directory basename (dim) + current branch in cyan; shows `(HEAD@<sha>)` in red for detached HEAD. The basename is trimmed to a 15-char `head…tail` middle ellipsis (7 chars each side) **only when the full status line would otherwise exceed 100 visible columns** — short lines keep the full name |
 | `3M 1A 1D 1R 2? 1!` | Working tree status, bucketed by VS Code-style codes: `M` = modified, `A` = added/staged, `D` = deleted, `R` = renamed, `?` = untracked. All shown dim. `!` = unmerged conflict, rendered separately in **red** because it's the only one that blocks a commit. Empty buckets are hidden — clean repo shows nothing |
 | `↑2 push` / `↓1 pull` | Local branch is ahead/behind `origin/<branch>` |

--- a/statusline.js
+++ b/statusline.js
@@ -29,6 +29,14 @@ process.stdin.on('end', () => {
       return suffix;
     };
     const model = shortModel(data.model?.display_name || 'Claude');
+    // Reasoning-effort tier, present on stdin only for models that support it
+    // (so it's stable, not flickering). Render as a fixed 2-letter code that
+    // sits inline right after the model. Unknown future levels fall back to the
+    // capitalised first two chars rather than vanishing.
+    const effortLevel = (data.effort?.level || '').toLowerCase();
+    const EFFORT_CODES = { low: 'Lo', medium: 'Md', high: 'Hi', xhigh: 'Xh', max: 'Mx' };
+    const effortCode = EFFORT_CODES[effortLevel]
+      || (effortLevel && effortLevel.slice(0, 2).replace(/^./, c => c.toUpperCase()));
     const dir = data.workspace?.current_dir || process.cwd();
     const session = data.session_id || '';
     const rawRemaining = data.context_window?.remaining_percentage;
@@ -352,7 +360,8 @@ process.stdin.on('end', () => {
       else if (detachedSha) s += ` \x1b[31m(HEAD@${detachedSha})\x1b[0m`;
       return s;
     };
-    const segments = [`\x1b[2m${model}\x1b[0m`];
+    const effortSeg = effortCode ? ` \x1b[2m${effortCode}\x1b[0m` : '';
+    const segments = [`\x1b[2m${model}\x1b[0m${effortSeg}`];
     const dirIndex = segments.length;
     segments.push(buildDirSegment(dirRaw));
     if (gitInfo) segments.push(gitInfo.trim());

--- a/tests/statusline-smoke.test.js
+++ b/tests/statusline-smoke.test.js
@@ -104,6 +104,32 @@ check('model shortening', () => {
   }
 });
 
+check('effort tier renders as a 2-letter code attached to the model', () => {
+  const dir = makeTempDir();
+
+  // No effort object → first segment is just the model (unsupported model / back-compat).
+  const none = runStatusline(inputFor(dir, { model: { display_name: 'Opus 4.8' } }));
+  assert.strictEqual(none.text.split(' │ ')[0], 'Op 4.8', `no effort: ${none.text}`);
+
+  // Each documented level maps to its dim 2-letter code (same as the model), glued to it.
+  const map = { low: 'Lo', medium: 'Md', high: 'Hi', xhigh: 'Xh', max: 'Mx' };
+  for (const [level, code] of Object.entries(map)) {
+    const { raw, text } = runStatusline(inputFor(dir, {
+      model: { display_name: 'Opus 4.8' },
+      effort: { level }
+    }));
+    assert.strictEqual(text.split(' │ ')[0], `Op 4.8 ${code}`, `${level}: ${text}`);
+    assert(raw.includes(`\x1b[2m${code}\x1b[0m`), `${level} should be dim like the model: ${raw}`);
+  }
+
+  // Unknown future level falls back to capitalised first two chars (never vanishes).
+  const future = runStatusline(inputFor(dir, {
+    model: { display_name: 'Opus 4.8' },
+    effort: { level: 'ultra' }
+  }));
+  assert.strictEqual(future.text.split(' │ ')[0], 'Op 4.8 Ul', `unknown level: ${future.text}`);
+});
+
 check('context bar width and glyphs', () => {
   const dir = makeTempDir();
   for (let used = 0; used <= 100; used += 10) {


### PR DESCRIPTION
## Summary

Claude Code reports the live reasoning-effort level on stdin as `effort.level` — one of `low`, `medium`, `high`, `xhigh`, `max` ([statusline docs](https://code.claude.com/docs/en/statusline)). It's present whenever the current model supports reasoning effort, so it's a stable signal rather than something that flickers in and out.

Surface it as a 2-letter code glued to the model segment, **dim — the same shade as the model** — so it reads as a quiet qualifier rather than competing with the other segments for attention:

```
Op 4.7 (1m) Hi │ claude-…tusline (main) │ …
```

| level | code |
|-------|------|
| `low` | `Lo` |
| `medium` | `Md` |
| `high` | `Hi` |
| `xhigh` | `Xh` |
| `max` | `Mx` |

Reflects mid-session `/effort` changes (the value is the live session level). Models that don't report `effort.level` render exactly as before — no segment, no change. An unrecognised future level falls back to its capitalised first two chars rather than disappearing.

## Diff

```js
+const effortLevel = (data.effort?.level || '').toLowerCase();
+const EFFORT_CODES = { low: 'Lo', medium: 'Md', high: 'Hi', xhigh: 'Xh', max: 'Mx' };
+const effortCode = EFFORT_CODES[effortLevel]
+  || (effortLevel && effortLevel.slice(0, 2).replace(/^./, c => c.toUpperCase()));
...
+const effortSeg = effortCode ? ` \x1b[2m${effortCode}\x1b[0m` : '';
-const segments = [`\x1b[2m${model}\x1b[0m`];
+const segments = [`\x1b[2m${model}\x1b[0m${effortSeg}`];
```

## Test plan

- [x] `node tests/statusline-smoke.test.js` — full suite passes
- [x] New test: each of the 5 levels maps to its dim code attached to the model (`Op 4.8 Hi`); no `effort` object → model only; unknown level → capitalised first two chars
- [x] Existing `model shortening` test unaffected (its inputs carry no `effort`)
- [x] README segment table updated
